### PR TITLE
fix/adjust-permissions-on-release-script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
   release:
     permissions:
       contents: write
+      pages: write
+      id-token: write
+  
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adjust permissions for id-token and gh-pages.